### PR TITLE
Update template.html

### DIFF
--- a/template.html
+++ b/template.html
@@ -7,7 +7,7 @@
 <head>
   <title></title>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <!--<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">-->
   <!--<meta name="viewport" content="width=device-width, initial-scale=1.0">-->
   <!--This one seems to work all the time, but really small on ipad-->
@@ -448,11 +448,6 @@ _gaq.push(['_trackPageview']);
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
 </script> -->
-
-<!--[if IE]>
-  <script src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
-  <script>CFInstall.check({mode: 'overlay'});</script>
-<![endif]-->
 
 </body>
 </html>


### PR DESCRIPTION
Removed unneeded ChromeFrame support - this has long since been discontinued by Google and is no longer available to download. (This PR is for Issue #24)

Added IE-edge X-UA-Compatible tag. This is recommended to prevent IE running in old-IE mode.
REF: https://www.modern.ie/en-gb/performance/how-to-use-x-ua-compatible

I've tested the above changes locally and live in production (and even made a presentation using it at the weekend :-) )